### PR TITLE
Switch cleanup

### DIFF
--- a/custom_components/tdarr/sensor.py
+++ b/custom_components/tdarr/sensor.py
@@ -227,7 +227,3 @@ class TdarrSensor(
                         qualities[quality["name"]] = quality["value"]
                     data["Resolutions"] = qualities
                     return data
-
-    @property
-    def device_id(self):
-        return self.device_id

--- a/custom_components/tdarr/switch.py
+++ b/custom_components/tdarr/switch.py
@@ -75,27 +75,21 @@ class TdarrSwitch(TdarrEntity, SwitchEntity):
         self.coordinator_context = object()
 
     async def async_turn_on(self, **kwargs):
-        update = await self.coordinator.hass.async_add_executor_job(
-            self.coordinator.tdarr.pauseNode,
-            self.object_name,
-            True
-        )
-
-        if update == "OK":
-            self._state = True
-            self.switch["nodePaused"] = True
-            self.async_write_ha_state()
+        return await self.async_set_paused(True)
 
     async def async_turn_off(self, **kwargs):
+        return await self.async_set_paused(False)
+
+    async def async_set_paused(self, paused: bool):
         update = await self.coordinator.hass.async_add_executor_job(
             self.coordinator.tdarr.pauseNode,
             self.object_name,
-            False
+            paused
         )
 
         if update == "OK":
-            self._state = False
-            self.switch["nodePaused"] = False
+            self._state = paused
+            self.switch["nodePaused"] = paused
             self.async_write_ha_state()
 
     @property

--- a/custom_components/tdarr/switch.py
+++ b/custom_components/tdarr/switch.py
@@ -93,10 +93,6 @@ class TdarrSwitch(TdarrEntity, SwitchEntity):
             self.async_write_ha_state()
 
     @property
-    def device_id(self):
-        return self.device_id
-
-    @property
     def is_on(self):
         if self._state == True:
             self._state = None


### PR DESCRIPTION
- Remove unused `device_id` property
- Remove repetition in switch turn on/off methods
- Rework switch toggle to use coordinator referesh