### PR TITLE
Fix duplicated devices when Tdarr nodes are restarted

### DIFF
--- a/custom_components/tdarr/api.py
+++ b/custom_components/tdarr/api.py
@@ -30,8 +30,13 @@ class TdarrApiClient(object):
         _LOGGER.debug("Retrieving nodes from %s", self._id)
         r = self._session.get('get-nodes')
         if r.status_code == 200:
-            result = r.json()
-            return result
+            data = r.json()
+
+            # Node IDs can change when node is restarted, so replace with node name instead.
+            # Fallback to ID if node name is unavailable for some reason.
+            data = { value.get("nodeName", key): value for key, value in data.items()}
+
+            return data
         else:
             return "ERROR"
 


### PR DESCRIPTION
Node IDs can change when a node is restarted, so we replace with node name instead.

If node name is unavailable for some reason, fallback to using the original key provided be Tdarr.

Resolves #21